### PR TITLE
workaround using setTimeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,18 @@ const Tilt = React.lazy(() => import('./tilt'))
 
 class App extends Component {
   state = {showTilt: false}
-  toggleTilt = () => this.setState(({showTilt}) => ({showTilt: !showTilt}))
+  toggleTilt = () =>
+    setTimeout(
+      () => this.setState(({showTilt}) => ({showTilt: !showTilt})),
+      100,
+    )
   render() {
     const {showTilt} = this.state
     return (
       <div>
         <label>
           show tilt
-          <input
-            type="checkbox"
-            checked={showTilt}
-            onChange={this.toggleTilt}
-          />
+          <input type="checkbox" onChange={this.toggleTilt} />
         </label>
 
         <div style={{height: 150, width: 200}} className="totally-centered">


### PR DESCRIPTION
`maxDuration` seems to work properly with these changes. I believe the issue is related to [this PR](https://github.com/facebook/react/pull/13832) (or, more directly, [this comment](https://github.com/facebook/react/pull/13832#issuecomment-429149978) on that PR)

Working theory: the `Suspense` render is being coupled with a high-priority user-blocking update (the checkbox) so the `maxDuration` is reverting to 0. If we decouple the checkbox state change with the Suspense rerender, `maxDuration` works as expected. 

